### PR TITLE
Update for jest >=28

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-const json5 = require("json5");
+const json5 = require('json5');
 
 module.exports = {
-  process: src => `module.exports = ${JSON.stringify(json5.parse(src))};`
+  process: (src) => {
+    return { code: `module.exports = ${JSON.stringify(json5.parse(src))};` };
+  },
 };


### PR DESCRIPTION
As per https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer this needs updating.

Not sure how your repo works / whether I need to update the versions of other libraries this works with?